### PR TITLE
Various improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ the link to understand why such a list is needed.
 See [test and benchmark](https://gorhill.github.io/publicsuffixlist.js/) pages.
 
 ## API
-
-    context.publicSuffixList = {
-        version: '2.0',
-        parse,
-        getDomain,
-        getPublicSuffix,
-        suffixInPSL,
-        toSelfie, fromSelfie,
-        disableWASM, enableWASM,
-    };
-
+```js
+context.publicSuffixList = {
+    version: '2.0',
+    parse,
+    getDomain,
+    getPublicSuffix,
+    suffixInPSL,
+    toSelfie, fromSelfie,
+    disableWASM, enableWASM
+};
+```
 ## Usage
 
-
-```js
+```html
 <script src="punycode.js"></script>
 <script src="publicsuffixlist.js"></script>
-
+```
+```js
 // window.publixSuffixList should now be present.
 
-...
+/* … */
 
 // Feed it the list (you choose how you obtain it).
 // `list` must be unicode text.
@@ -42,7 +42,7 @@ See [test and benchmark](https://gorhill.github.io/publicsuffixlist.js/) pages.
 // awesome: https://github.com/bestiejs/punycode.js).
 window.publicSuffixList.parse(list, punycode.toASCII);
 
-...
+/* … */
 
 // Caller is responsible to pass in hostnames which are "canonicalized in the
 // normal way for hostnames": lower-case, punycode, and only a-z, 0-9, -, .
@@ -50,10 +50,10 @@ window.publicSuffixList.parse(list, punycode.toASCII);
 let domain = window.publicSuffixList.getDomain('haha.whatisthis.global.prod.fastly.net');
 // domain = 'whatisthis.global.prod.fastly.net'
 
-let domain = window.publicSuffixList.getDomain('police.uk');
+domain = window.publicSuffixList.getDomain('police.uk');
 // domain = ''
 
-let domain = window.publicSuffixList.getDomain('www.xn--85x722f.xn--55qx5d.cn');
+domain = window.publicSuffixList.getDomain('www.xn--85x722f.xn--55qx5d.cn');
 // domain = 'xn--85x722f.xn--55qx5d.cn'
 
 // Etc.
@@ -61,14 +61,16 @@ let domain = window.publicSuffixList.getDomain('www.xn--85x722f.xn--55qx5d.cn');
 
 ## Usage with node.js
 
-
+```sh
+npm install gorhill/publicsuffixlist.js
 ```
-const suffixList = require('./publicsuffixlist');
+```js
+const suffixList = require('publicsuffixlist');
 // For utf-8 conversion - npm install punycode
-const punycode = require('punycode'); 
+const punycode = require('punycode/'); 
 const fs = require('fs');
 
-// Suffix list downloaded from https://publicsuffix.org/list/public_suffix_list.dat.dat
+// Suffix list downloaded from https://publicsuffix.org/list/public_suffix_list.dat
 const suffixData = fs.readFileSync('./public_suffix_list.dat', 'utf8');
 
 suffixList.parse(suffixData, punycode.toASCII);
@@ -79,7 +81,7 @@ let domain = suffixList.getDomain('haha.whatisthis.global.prod.fastly.net');
 domain = suffixList.getDomain('police.uk');
 // domain = ''
 
- domain = suffixList.getDomain('www.xn--85x722f.xn--55qx5d.cn');
+domain = suffixList.getDomain('www.xn--85x722f.xn--55qx5d.cn');
 // domain = 'xn--85x722f.xn--55qx5d.cn'
 
 ```


### PR DESCRIPTION
- Applies syntax highlighting
- Moved HTML from `js` codeblock into `html` codeblock
- Removed `let` instances for consistent examples across browser/node scenarios
- Added trailing `/` in punycode _require_, to avoid confusion (see note [here](https://github.com/bestiejs/punycode.js#installation)
- Demonstrates installing dep from GitHub repository
- Removed extra extension from suffixlist address