### PR TITLE
Fix docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ publicSuffixList = {
 
 ```html
 <script src="punycode.js"></script>
-<script type="module>
+<script type="module">
 import publicSuffixList from 'publicsuffixlist.js';
 
 /* … */

--- a/docs/benchmark.html
+++ b/docs/benchmark.html
@@ -26,7 +26,7 @@
 <script src="punycode.min.js"></script>
 <script>
 const pslV1URL = 'https://rawcdn.githack.com/gorhill/publicsuffixlist.js/f76f6bcdb7dcc951fa8e8739527fa3340469401e/publicsuffixlist.min.js';
-const pslV2URL = 'https://raw.githack.com/gorhill/publicsuffixlist.js/master/publicsuffixlist.min.js';
+const pslV2URL = 'https://rawcdn.githack.com/gorhill/publicsuffixlist.js/1b9d19a2698c6990947556d2ad62d2166d1afe7e/publicsuffixlist.min.js';
 const pslInstances = {};
 
 const urijs = new URI();

--- a/docs/test.html
+++ b/docs/test.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <script src="punycode.min.js"></script>
-<script src="https://raw.githack.com/gorhill/publicsuffixlist.js/master/publicsuffixlist.js"></script>
 </head>
 <body style="font: 14px sans-serif">
 <h1>Tests</h1>
@@ -15,7 +14,9 @@ available on <a href="http://publicsuffix.org/list/">publicsuffix.org</a>.</p>
 
 <div id="result"></div>
 
-<script>
+<script type="module">
+import publicSuffixList from 'https://raw.githack.com/gorhill/publicsuffixlist.js/master/publicsuffixlist.js';
+
 function stdout(html) {
     const div = document.createElement('div');
     div.style.whiteSpace = 'pre-line';
@@ -56,16 +57,14 @@ fetch(
     publicSuffixList.parse(text, punycode.toASCII);
     stdout('JS');
     checkAll();
-    publicSuffixList.enableWASM().then(status => {
+    /*publicSuffixList.enableWASM().then(status => {
         if ( status === true ) {
             stdout('\nWASM');
             checkAll();
         }
-    });
+    });*/
 });
-</script>
 
-<script>
 function checkAll() {
     // Any copyright is dedicated to the Public Domain.
     // https://creativecommons.org/publicdomain/zero/1.0/


### PR DESCRIPTION
Fixes `test.html` (sans Wasm) and `benchmark.html` (v1 and v2 only) in `./docs` and also the HTML example in `README.md`.