### PR TITLE
Remove redundant call to trim()

### DIFF
--- a/publicsuffixlist.js
+++ b/publicsuffixlist.js
@@ -229,7 +229,7 @@ const parse = function(text, toAscii) {
                     lineEnd = textEnd;
                 }
             }
-            let line = text.slice(lineBeg, lineEnd).trim();
+            let line = text.slice(lineBeg, lineEnd);
             lineBeg = lineEnd + 1;
 
             // Ignore comments


### PR DESCRIPTION
The first call to `String#trim()` is not really necessary since it doesn't affect the outcome of what follows.