### PR TITLE
Add show-memory-usage script

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 node_modules/
 coverage/
+scripts/
+tests/
 *.heapsnapshot

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "publicsuffixlist.js",
   "type": "module",
   "scripts": {
+    "show-memory-usage": "node --expose-gc scripts/show-memory-usage.js",
     "test": "c8 --include=publicsuffixlist.js mocha --experimental-vm-modules --no-warnings tests --check-leaks"
   },
   "repository": {

--- a/scripts/show-memory-usage.js
+++ b/scripts/show-memory-usage.js
@@ -1,0 +1,91 @@
+/*******************************************************************************
+
+    publicsuffixlist.js - an efficient javascript implementation to deal with
+    Mozilla Foundation's Public Suffix List <http://publicsuffix.org/list/>
+
+    Copyright (C) 2013-present Raymond Hill
+
+    License: pick the one which suits you:
+      GPL v3 see <https://www.gnu.org/licenses/gpl.html>
+      APL v2 see <http://www.apache.org/licenses/LICENSE-2.0>
+
+*/
+
+import { createWriteStream, readFileSync } from 'fs';
+import { domainToASCII } from 'url';
+import v8 from 'v8';
+
+const content = readFileSync('./docs/public_suffix_list.dat', 'utf8');
+
+let publicSuffixList = null;
+
+function wait(milliseconds) {
+    return new Promise(resolve => {
+        setTimeout(resolve, milliseconds);
+    });
+}
+
+function printMemoryUsage(label, values) {
+    console.log(label);
+    console.log(` *  Heap used: ${Math.ceil(values.heapUsed / 1024).toLocaleString()} KiB`);
+    console.log(` *  Heap total: ${Math.ceil(values.heapTotal / 1024).toLocaleString()} KiB`);
+    console.log();
+}
+
+async function memoryUsage() {
+    return process.memoryUsage();
+}
+
+async function runGC() {
+    gc();
+
+    await wait(1000);
+}
+
+function saveHeapSnapshot(name) {
+    const snapshotStream = v8.getHeapSnapshot();
+    const fileStream = createWriteStream(`${name}.heapsnapshot`);
+    snapshotStream.pipe(fileStream);
+}
+
+(async function () {
+    const now = Date.now();
+
+    await runGC();
+
+    if ( process.argv[2] === '--heap-snapshot' ) {
+        saveHeapSnapshot(`${now}--initial`);
+    }
+
+    printMemoryUsage('Initial:', await memoryUsage());
+
+    publicSuffixList = (await import('../publicsuffixlist.js')).default;
+
+    printMemoryUsage('On import():', await memoryUsage());
+
+    publicSuffixList.parse(content, domainToASCII);
+
+    printMemoryUsage('On parse():', await memoryUsage());
+
+    publicSuffixList.getDomain('example.com');
+
+    printMemoryUsage(`On getDomain('example.com'):`, await memoryUsage());
+
+    publicSuffixList.getDomain('example.s3-website.us-east-2.amazonaws.com');
+
+    printMemoryUsage(`On getDomain('example.s3-website.us-east-2.amazonaws.com'):`,
+                     await memoryUsage());
+
+    publicSuffixList.getDomain('this.is.a.very.long.hostname.that.does.not.have.a.public.suffix');
+
+    printMemoryUsage(`On getDomain('this.is.a.very.long.hostname.that.does.not.have.a.public.suffix'):`,
+                     await memoryUsage());
+
+    await runGC();
+
+    if ( process.argv[2] === '--heap-snapshot' ) {
+        saveHeapSnapshot(`${now}--after-gc`);
+    }
+
+    printMemoryUsage('After GC:', await memoryUsage());
+})();


### PR DESCRIPTION
The `show-memory-usage.js` script shows the memory usage of Node.js at various stages of using the publicsuffixlist.js package.

```
npm run show-memory-usage
npm run show-memory-usage -- --heap-snapshot
```

Use `--heap-snapshot` to get heap snapshots for the initial and final stages. Load the `.heapsnapshot` files in Chrome's developer tools for analysis.

Output:

```
Initial:
 *  Heap used: 2,372 KiB
 *  Heap total: 4,972 KiB

On import():
 *  Heap used: 2,647 KiB
 *  Heap total: 4,972 KiB

On parse():
 *  Heap used: 5,663 KiB
 *  Heap total: 9,104 KiB

On getDomain('example.com'):
 *  Heap used: 5,672 KiB
 *  Heap total: 9,104 KiB

On getDomain('example.s3-website.us-east-2.amazonaws.com'):
 *  Heap used: 5,678 KiB
 *  Heap total: 9,104 KiB

On getDomain('this.is.a.very.long.hostname.that.does.not.have.a.public.suffix'):
 *  Heap used: 5,682 KiB
 *  Heap total: 9,104 KiB

After GC:
 *  Heap used: 2,542 KiB
 *  Heap total: 7,580 KiB

```