### PR TITLE
Implement publicSuffixToASCII()

### DIFF
--- a/docs/test.html
+++ b/docs/test.html
@@ -3,7 +3,6 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<script src="punycode.min.js"></script>
 </head>
 <body style="font: 14px sans-serif">
 <h1>Tests</h1>
@@ -15,7 +14,8 @@ available on <a href="http://publicsuffix.org/list/">publicsuffix.org</a>.</p>
 <div id="result"></div>
 
 <script type="module">
-import publicSuffixList from 'https://raw.githack.com/gorhill/publicsuffixlist.js/master/publicsuffixlist.js';
+import publicSuffixList from '../publicsuffixlist.js';
+import { publicSuffixToASCII } from '../publicsuffixlist.js';
 
 function stdout(html) {
     const div = document.createElement('div');
@@ -31,8 +31,8 @@ const resultTemplateBad = '<span style="color:red">Failure: got {{r}} instead</s
 function checkPublicSuffix(a, b) {
     // publicSuffixList() does not normalize Unicode, it is the caller's
     // responsibility, because overhead etc.
-    const anorm = a ? punycode.toASCII(a) : a;
-    const bnorm = b ? punycode.toASCII(b) : b;
+    const anorm = a ? publicSuffixToASCII(a) : a;
+    const bnorm = b ? publicSuffixToASCII(b) : b;
 
     let r = publicSuffixList.getDomain(anorm);
     if ( !r ) {
@@ -54,7 +54,7 @@ fetch(
 }).then(response =>
     response.text()
 ).then(text => {
-    publicSuffixList.parse(text, punycode.toASCII);
+    publicSuffixList.parse(text, publicSuffixToASCII);
     stdout('JS');
     checkAll();
     publicSuffixList.enableWASM().then(status => {

--- a/publicsuffixlist.js
+++ b/publicsuffixlist.js
@@ -645,3 +645,40 @@ class PublicSuffixList {
 export default new PublicSuffixList();
 
 /******************************************************************************/
+
+const psURL = new URL('ws://x');
+
+// Experimental alternative to punycode.js but only for entries in the public
+// suffix list.
+
+export function publicSuffixToASCII(publicSuffix) {
+    // If the public suffix contains an underscore as a label, consider it an
+    // error.
+    if ( /(^|\.)_(\.|$)/u.test(publicSuffix) )
+        return '';
+
+    // https://publicsuffix.org/list/
+
+    // The asterisk is not a valid domain name character. A public suffix can't
+    // contain underscores as labels. The underscore is a valid domain name
+    // character. Therefore, we convert asterisks as labels to underscores as
+    // labels. e.g. state.*.us becomes state._.us
+    publicSuffix = publicSuffix.replace(/(^|\.)\*(\.|$)/gu, '$1_$2');
+
+    // Set the hostname to "x" first.
+    psURL.hostname = 'x';
+
+    // Let the URL object do the conversion.
+    psURL.hostname = publicSuffix;
+    const converted = psURL.hostname;
+
+    // If the converted hostname is "x" and the original hostname is not "x" it
+    // means there was an error.
+    if ( converted === 'x' && publicSuffix !== 'x' )
+        return '';
+
+    // Convert underscores as labels back to asterisks as labels.
+    return converted.replace(/(^|\.)_(\.|$)/gu, '$1*$2');
+}
+
+/******************************************************************************/

--- a/publicsuffixlist.js
+++ b/publicsuffixlist.js
@@ -654,7 +654,7 @@ const psURL = new URL('ws://x');
 export function publicSuffixToASCII(publicSuffix) {
     // If the public suffix contains an underscore as a label, consider it an
     // error.
-    if ( /(^|\.)_(\.|$)/u.test(publicSuffix) )
+    if ( publicSuffix.includes('_') && /(^|\.)_(\.|$)/u.test(publicSuffix) )
         return '';
 
     // https://publicsuffix.org/list/
@@ -663,13 +663,15 @@ export function publicSuffixToASCII(publicSuffix) {
     // contain underscores as labels. The underscore is a valid domain name
     // character. Therefore, we convert asterisks as labels to underscores as
     // labels. e.g. state.*.us becomes state._.us
-    publicSuffix = publicSuffix.replace(/(^|\.)\*(\.|$)/gu, '$1_$2');
+    const publicSuffix_ = publicSuffix.includes('*') ?
+                              publicSuffix.replace(/(^|\.)\*(\.|$)/gu, '$1_$2') :
+                              publicSuffix;
 
     // Set the hostname to "x" first.
     psURL.hostname = 'x';
 
     // Let the URL object do the conversion.
-    psURL.hostname = publicSuffix;
+    psURL.hostname = publicSuffix_;
     const converted = psURL.hostname;
 
     // If the converted hostname is "x" and the original hostname is not "x" it
@@ -678,7 +680,9 @@ export function publicSuffixToASCII(publicSuffix) {
         return '';
 
     // Convert underscores as labels back to asterisks as labels.
-    return converted.replace(/(^|\.)_(\.|$)/gu, '$1*$2');
+    return publicSuffix_ !== publicSuffix ?
+               converted.replace(/(^|\.)_(\.|$)/gu, '$1*$2') :
+               converted;
 }
 
 /******************************************************************************/


### PR DESCRIPTION
This is a second attempt at an alternative implementation of punycode.js's `toASCII()` function for the purpose of converting a public suffix to an IDNA-encoded name.

At the moment it's experimental and used only in `test.html`.