### PR TITLE
Ignore wildcards for Punycode check

### DIFF
--- a/publicsuffixlist.js
+++ b/publicsuffixlist.js
@@ -219,7 +219,7 @@ class PublicSuffixList {
             // 2. If no rules match, the prevailing rule is "*".
             addToTree('*', false);
 
-            const mustPunycode = /[^a-z0-9.-]/;
+            const mustPunycode = /[^*a-z0-9.-]/;
             const textEnd = text.length;
             let lineBeg = 0;
 


### PR DESCRIPTION
```console
$ sed 's/\/\/.*//' docs/public_suffix_list.dat | grep -iE '[^a-z0-9.-]' | wc -l
514
$ sed 's/\/\/.*//' docs/public_suffix_list.dat | grep -iE '[^a-z0-9.-]' | grep '*' | wc -l
58
$ 
```

Of the domains that are converted to Punycode, about ten percent are only because they have a `*` (wildcard). There's no need to convert these.