### PR TITLE
Remove cache option to setup-node action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,6 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: '14'
-        cache: 'npm'
 
     - name: Run tests
       run: npm run docs-test


### PR DESCRIPTION
Since we are not installing dependencies in the `tests.yml` file, there's no need for setting the cache option.