### PR TITLE
Add fuzz-to-kill script

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,3 +19,6 @@ jobs:
 
     - name: Run tests
       run: npm run docs-test
+
+    - name: Run fuzzer
+      run: npm run fuzz-to-kill

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "docs-test": "node scripts/docs-test.js",
+    "fuzz-to-kill": "node scripts/fuzz-to-kill.js",
     "show-memory-usage": "node --expose-gc scripts/show-memory-usage.js",
     "test": "c8 --include=publicsuffixlist.js mocha --experimental-vm-modules --no-warnings tests --check-leaks"
   },

--- a/scripts/fuzz-to-kill.js
+++ b/scripts/fuzz-to-kill.js
@@ -1,0 +1,34 @@
+/*******************************************************************************
+
+    publicsuffixlist.js - an efficient javascript implementation to deal with
+    Mozilla Foundation's Public Suffix List <http://publicsuffix.org/list/>
+
+    Copyright (C) 2013-present Raymond Hill
+
+    License: pick the one which suits you:
+      GPL v3 see <https://www.gnu.org/licenses/gpl.html>
+      APL v2 see <http://www.apache.org/licenses/LICENSE-2.0>
+
+*/
+
+import { randomBytes } from 'crypto';
+import { domainToASCII } from 'url';
+
+import publicSuffixList from '../publicsuffixlist.js';
+
+for ( let i = 0; i < 100; i++ ) {
+  // Up to ~16 MiB or 0xFFFF00 bytes
+  const bytes = randomBytes(randomBytes(2).readUIntLE(0, 2) << 8);
+  console.log(`${bytes.length.toLocaleString()} random bytes`);
+
+  const string = bytes.toString('utf8');
+
+  console.time('parse');
+  publicSuffixList.parse(string, domainToASCII);
+  console.timeEnd('parse');
+
+  console.log();
+}
+
+console.log('Yay, we made it!');
+console.log();


### PR DESCRIPTION
This patch adds a script called `fuzz-to-kill` that passes up to ~16 MiB of random gibberish to the parser to see how it behaves. It also prints the time taken to parse the input. The program should not crash or take too long to process the input.

The `tests.yml` workflow script runs this fuzzer after the tests.